### PR TITLE
Added pages extension to Dockerfile and spatial search in sidebar.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN pip install --no-cache-dir -e "git+https://github.com/keitaroinc/ckanext-dat
     pip install --no-cache-dir -r "${APP_DIR}/src/ckanext-datagovmk/requirements.txt" && \
     # Install extensions
     # ckanext-spatial and related
-    pip install --no-cache-dir -e "git+https://github.com/ckan/ckanext-spatial.git#egg=ckanext-spatial" && \
+    pip install --no-cache-dir -e "git+https://github.com/keitaroinc/ckanext-spatial.git@ckan-2.8#egg=ckanext-spatial" && \
     pip install --no-cache-dir -r "${APP_DIR}/src/ckanext-spatial/pip-requirements.txt" && \
     pip install --no-cache-dir ckanext-geoview && \
     pip install --no-cache-dir -e "git+https://github.com/datagovuk/ckanext-report.git#egg=ckanext-report" && \
@@ -57,7 +57,10 @@ RUN pip install --no-cache-dir -e "git+https://github.com/keitaroinc/ckanext-dat
     pip install --no-cache-dir -r "${APP_DIR}/src/ckanext-mk-dcatap/requirements.txt" && \
     # envvars
     pip install --no-cache-dir -e "git+https://github.com/okfn/ckanext-envvars.git#egg=ckanext-envvars" && \
-    pip install --no-cache-dir -r "${APP_DIR}/src/ckanext-envvars/dev-requirements.txt"
+    pip install --no-cache-dir -r "${APP_DIR}/src/ckanext-envvars/dev-requirements.txt" && \
+    # pages
+    pip install --no-cache-dir -e "git+https://github.com/keitaroinc/ckanext-pages.git@news#egg=ckanext-pages" && \
+    pip install --no-cache-dir -r "${APP_DIR}/src/ckanext-pages/dev-requirements.txt"
     
 
 
@@ -89,6 +92,7 @@ ENV CKAN__PLUGINS envvars \
                   dcat_json_interface \
                   structured_data \
                   c3charts \
+                  pages \
                   datagovmk \
                   mk_dcatap
 

--- a/ckanext/datagovmk/fanstatic/less/main.less
+++ b/ckanext/datagovmk/fanstatic/less/main.less
@@ -474,23 +474,6 @@
   }
 }
 
-/* CKAN spatial extension*/
-
-.dataset-map-expanded {
-  #dataset-map {
-    top: -@navbar-height;
-    height: 394px;
-    z-index: @zindex-modal;
-  }
-}
-#dataset-search-form {
-  .search-input-group{
-    opacity: 0.999;  /* This is the giant search field, which due to `position:relative` and the
-                        `z-index` set on the children was always displayed on top of the map 
-                        irrelevant of the maps `z-index`. */
-  }
-}
-
 /* Media queries */
 
 /* Up to the small size breakpoint */

--- a/ckanext/datagovmk/fanstatic/less/main.less
+++ b/ckanext/datagovmk/fanstatic/less/main.less
@@ -474,6 +474,23 @@
   }
 }
 
+/* CKAN spatial extension*/
+
+.dataset-map-expanded {
+  #dataset-map {
+    top: -@navbar-height;
+    height: 394px;
+    z-index: @zindex-modal;
+  }
+}
+#dataset-search-form {
+  .search-input-group{
+    opacity: 0.999;  /* This is the giant search field, which due to `position:relative` and the
+                        `z-index` set on the children was always displayed on top of the map 
+                        irrelevant of the maps `z-index`. */
+  }
+}
+
 /* Media queries */
 
 /* Up to the small size breakpoint */

--- a/ckanext/datagovmk/templates/package/search.html
+++ b/ckanext/datagovmk/templates/package/search.html
@@ -2,6 +2,6 @@
 
 {% block secondary_content %}
   {{ super() }}
-  {# snippet "spatial/snippets/spatial_query.html" #}
+  {% snippet "spatial/snippets/spatial_query.html" %}
 
 {% endblock %}


### PR DESCRIPTION
I've added ckanext-pages (branch ```news```) to the Dockerfile.
I've also added the spatial search snippet to the search sidebar.

**Note** that when clicking to expand the map it goes up and behind the sites header. This does not happen in CKAN with the default theme - the map goes just bellow the breadcrumb and pushes the main content (filters + search and search results) down - so it comes between the header and the main content.