### PR TITLE
Create link for extras

### DIFF
--- a/ckanext/datagovmk/templates/package/snippets/additional_info.html
+++ b/ckanext/datagovmk/templates/package/snippets/additional_info.html
@@ -1,0 +1,14 @@
+{% ckan_extends %}
+{% block extras scoped %}
+    {% for extra in h.sorted_extras(pkg_dict.extras) %}
+    {% set key, value = extra %}
+    <tr rel="dc:relation" resource="_:extra{{ i }}">
+    <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
+        {% if h.is_url(value) %}
+            <td class="dataset-details" property="rdf:value">{{ h.link_to(value, value, rel='rdf:value', target='_blank') }}</td>
+        {% else %}
+            <td class="dataset-details" property="rdf:value">{{ value }}</td>
+        {% endif %}
+    </tr>
+    {% endfor %}
+{% endblock %}    


### PR DESCRIPTION
In the Additional info table shown on every dataset page, where extras are displayed, if the value for the extra contains a link it will automatically generate an HTML tag so that the link can be clickable.
Please note that in order to test this functionality you need to pull the latest changes from the keitaroinc/requestdata extension from the ckan-2.8 branch