### PR TITLE
Translating the ISO-3166-2 code to OSM Location URI.

### DIFF
--- a/ckanext/datagovmk/utils.py
+++ b/ckanext/datagovmk/utils.py
@@ -13,6 +13,7 @@ from ckanext.dcat.utils import resource_uri
 from ckan.model.license import LicenseRegister
 from ckanext.dcat.processors import RDFSerializer
 from ckan.common import config
+from ckan.lib.helpers import helper_functions
 import requests
 
 
@@ -310,9 +311,11 @@ def get_package_location_geojson(package_dict):
 
     :returns: ``str`` the GeoJSON data string.
     """
+
     location_uri = package_dict.get('spatial_uri')
     if not location_uri:
         return None
+    location_uri = _code_to_spatial_uri(location_uri)
     resource_id = _extract_spatial_resource_id(location_uri)
     if not resource_id:
         return None
@@ -388,3 +391,15 @@ def _get_geojson(resource):
     if geojson_dict:
         return json.dumps(geojson_dict)
     return None
+
+
+def _get_helper(helper):
+    return helper_functions.get(helper)
+
+
+def _code_to_spatial_uri(code):
+    code_to_uri = _get_helper('mk_dcatap_spatial_uri_from_code')
+    if code_to_uri:
+        uri = code_to_uri(code)
+        return uri or code
+    return code


### PR DESCRIPTION
Keeps the ISO location codes in metadata, but translates the codes to OSM URL for fetching the geospatial data for particular location (if provided) in a dataset metadata.