### PR TITLE
Email notifications

### DIFF
--- a/ckanext/datagovmk/plugin.py
+++ b/ckanext/datagovmk/plugin.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import ckanext.datagovmk.helpers as helpers
@@ -7,6 +9,58 @@ from routes.mapper import SubMapper
 from ckanext.datagovmk import actions
 from ckanext.datagovmk import auth
 from ckanext.datagovmk.logic import import_spatial_data
+from ckan.lib import email_notifications
+from ckan.lib import base
+from ckan.common import config
+
+
+def _notifications_for_activities(activities, user_dict):
+    '''Return one or more email notifications covering the given activities.
+
+    This function handles grouping multiple activities into a single digest
+    email.
+
+    :param activities: the activities to consider
+    :type activities: list of activity dicts like those returned by
+        ckan.logic.action.get.dashboard_activity_list()
+
+    :returns: a list of email notifications
+    :rtype: list of dicts each with keys 'subject' and 'body'
+
+    '''
+    if not activities:
+        return []
+
+    if not user_dict.get('activity_streams_email_notifications'):
+        return []
+
+    # We just group all activities into a single "new activity" email that
+    # doesn't say anything about _what_ new activities they are.
+    # TODO: Here we could generate some smarter content for the emails e.g.
+    # say something about the contents of the activities, or single out
+    # certain types of activity to be sent in their own individual emails,
+    # etc.
+    
+    if len(activities) > 1:
+        subject = u"{n} нови активности од {site_title} /{n} aktivitete të reja nga {site_title}/{n} new activities from {site_title}".format(
+                site_title=config.get('ckan.site_title'),
+                n=len(activities))
+    else:
+        subject = u"{n} нова активност од {site_title} / {n} aktivitet i ri nga {site_title} / {n} new activity from {site_title}".format(
+                site_title=config.get('ckan.site_title'),
+                n=len(activities))
+    body = base.render(
+            'activity_streams/activity_stream_email_notifications.text',
+            extra_vars={'activities': activities})
+
+    notifications = [{
+        'subject': subject,
+        'body': body
+    }]
+
+    return notifications
+
+email_notifications._notifications_for_activities=_notifications_for_activities
 
 
 class DatagovmkPlugin(plugins.SingletonPlugin, DefaultTranslation):

--- a/ckanext/datagovmk/templates/activity_streams/activity_stream_email_notifications.text
+++ b/ckanext/datagovmk/templates/activity_streams/activity_stream_email_notifications.text
@@ -1,0 +1,28 @@
+{% set num = activities|length %}{{ ungettext("Вие имате {num} нови активности на Вашата {site_title} табла.", "Вие имате {num} нови активности на Вашата {site_title} табла", num).format(site_title=g.site_title, num=num) }} {{ _('За да ја видите контролната табла, кликнете на овој линк:') }}
+
+{{ g.site_url + '/dashboard' }}
+
+{{ 'Можете да ги исклучите овие е-мејл известувања во вашите {site_title} параметри. За да ги промените вашите параметри, кликнете на овој линк:'.format(site_title=g.site_title) }}
+
+{{ g.site_url + '/user/edit' }}
+
+
+
+{% set num = activities|length %}{{ ungettext("Ju keni {num} aktivitet të ri në panelin e kontrollit tuaj {site_title}.", "Ju keni aktivitete të reja {num} në panelin e kontrollit {site_title}", num).format(site_title=g.site_title, num=num) }} {{ _('Për të parë pultin tuaj, klikoni në këtë link:') }}
+
+{{ g.site_url + '/dashboard' }}
+
+{{ "Ju mund të çaktivizoni këto njoftime përmes emailit në preferencat tuaja {site_title}. Për të ndryshuar preferencat tuaja, klikoni në këtë link:".format(site_title=g.site_title) }}
+
+{{ g.site_url + '/user/edit' }}
+
+
+
+{% set num = activities|length %}{{ ungettext("You have {num} new activity on your {site_title} dashboard.", "You have {num} new activities on your {site_title} dashboard", num).format(site_title=g.site_title, num=num) }} {{ _('To view your dashboard, click on this link:') }}
+
+{{ g.site_url + '/dashboard' }}
+
+{{ 'You can turn off these email notifications in your {site_title} preferences. To change your preferences, click on this link:'.format(site_title=g.site_title) }}
+
+{{ g.site_url + '/user/edit' }}
+


### PR DESCRIPTION
With this change, the subject and the body of the e-mail notification are now available in three languages (English, Macedonian and Albanian).

Instructions on how to setup E-mail notifications can be found on the following link:
http://docs.ckan.org/en/2.8/maintaining/email-notifications.html


