### PR TITLE
Bugs/download dataset resources multiple issues

### DIFF
--- a/ckanext/datagovmk/actions.py
+++ b/ckanext/datagovmk/actions.py
@@ -244,27 +244,6 @@ def prepare_zip_resources(context, data_dict):
     return {'zip_id': None}
 
 
-@toolkit.side_effect_free
-def download_zip(context, data_dict):
-    """Downloads a zip file
-
-    :param id: an id of the created zip archive, format: filename::packagename
-    :type id: string
-    """
-    file_name, package_name = data_dict.get('id').split('::')
-    file_path = h.get_storage_path_for('temp-datagovmk/' + file_name)
-
-    if not package_name:
-        package_name = 'resources'
-    package_name += '.zip'
-
-    with open(file_path, 'r') as f:
-        toolkit.response.write(f.read())
-
-    toolkit.response.content_disposition = 'attachment; filename=' + package_name
-    os.remove(file_path)
-
-
 def safe_override(action):
     """Decorator for save override of standard CKAN actions.
     When overriding CKAN actions you must be aware of the extensions

--- a/ckanext/datagovmk/controller.py
+++ b/ckanext/datagovmk/controller.py
@@ -561,7 +561,6 @@ def get_admin_email():
 class OverrideDatastoreController(DatastoreController):
 
     def dump(self, resource_id):
-        print " ------> THIS DUMP"
         try:
             offset = int_validator(request.GET.get('offset', 0), {})
         except toolkit.Invalid as e:
@@ -613,7 +612,6 @@ def dump_to(resource_id, output, fmt, offset, limit, options):
         writer_factory = xml_writer
         records_format = 'objects'
 
-    print '   ----> this dump_to FO REAL'
     def start_writer(fields):
         bom = options.get(u'bom', False)
         return writer_factory(output, fields, resource_id, bom)

--- a/ckanext/datagovmk/controller.py
+++ b/ckanext/datagovmk/controller.py
@@ -116,6 +116,26 @@ class DownloadController(PackageController):
         elif 'url' not in rsc:
             abort(404, toolkit._('No download is available'))
         h.redirect_to(rsc['url'])
+    
+    def download_zip(self, zip_id):
+        if not zip_id:
+            abort(404, toolkit._('Resource data not found'))
+        file_name, package_name = zip_id.split('::')
+        file_path = get_storage_path_for('temp-datagovmk/' + file_name)
+
+        if not os.path.isfile(file_path):
+            abort(404, toolkit._('Resource data not found'))
+            
+        if not package_name:
+            package_name = 'resources'
+        package_name += '.zip'
+
+        with open(file_path, 'r') as f:
+            response.write(f.read())
+
+        response.headers['Content-Type'] = 'application/octet-stream'
+        response.content_disposition = 'attachment; filename=' + package_name
+        os.remove(file_path)
 
 
 class ApiController(BaseController):

--- a/ckanext/datagovmk/fanstatic/js/download-resources.js
+++ b/ckanext/datagovmk/fanstatic/js/download-resources.js
@@ -79,7 +79,7 @@ $(document).ready(function () {
 
       if (zip_id) {
         var link = document.createElement('a');
-        url = window.location.origin + '/api/action/datagovmk_download_zip?id=' + zip_id;
+        url = window.location.origin + '/download/zip/' + zip_id;
         link.style.display = 'none';
         link.href = url;
         document.body.appendChild(link);

--- a/ckanext/datagovmk/plugin.py
+++ b/ckanext/datagovmk/plugin.py
@@ -194,6 +194,10 @@ class DatagovmkPlugin(plugins.SingletonPlugin, DefaultTranslation):
                     controller='ckanext.datagovmk.controller:ReportIssueController',
                     action='report_issue_form')
 
+        map.connect('/datastore/dump/{resource_id}',
+                    controller='ckanext.datagovmk.controller:OverrideDatastoreController',
+                    action='dump')
+
         return map
 
     def configure(self, config):

--- a/ckanext/datagovmk/plugin.py
+++ b/ckanext/datagovmk/plugin.py
@@ -125,7 +125,6 @@ class DatagovmkPlugin(plugins.SingletonPlugin, DefaultTranslation):
         return {
             'datagovmk_get_related_datasets': actions.get_related_datasets,
             'datagovmk_prepare_zip_resources': actions.prepare_zip_resources,
-            'datagovmk_download_zip': actions.download_zip,
             'package_create': actions.add_spatial_data(package_create),
             'package_update': actions.add_spatial_data(package_update),
             'resource_create': actions.resource_create,
@@ -184,6 +183,9 @@ class DatagovmkPlugin(plugins.SingletonPlugin, DefaultTranslation):
             m.connect('resource_download',
                       '/dataset/{id}/resource/{resource_id}/download/{filename}',
                       action='resource_download')
+            m.connect('download_zip',
+                      '/download/zip/{zip_id}',
+                      action='download_zip')
 
         # map user routes
         with SubMapper(map, controller='ckanext.datagovmk.controller:DatagovmkUserController') as m:


### PR DESCRIPTION
Fixed the serialization of resources to XML (had to override some parts of ckanext/datastore, the bug was in CKAN writer.XMLWriter - based on Konstantin's PR: https://github.com/ckan/ckan/pull/3914).
To test this, create some CSV resource with column name that contains spaces, and try to download it.

Also fixed the ZIP archive generation - we were returning ```Content-Type: application/json``` when downloading the ZIP archive  -so I moved the download logic to a controller (instead of an action) and set the Content type to ```application/octet-stream```. 
To test it, select multiple resources from the dataset page ad click "Dowload". The response should have the proper content type header and the browser should suggest opening the file with appropriate application (if available).