### PR TITLE
Fix incrementing downloads for a resource

### DIFF
--- a/ckanext/datagovmk/actions.py
+++ b/ckanext/datagovmk/actions.py
@@ -38,6 +38,7 @@ from ckan.logic.action.get import package_search as _package_search
 from ckan.logic.action.get import resource_show as _resource_show
 from ckan.logic.action.get import organization_show as _organization_show
 from ckan.logic.action.get import group_show as _group_show
+from ckanext.datagovmk.model.stats import increment_downloads
 
 log = getLogger(__name__)
 
@@ -237,6 +238,8 @@ def prepare_zip_resources(context, data_dict):
         pass
 
     if resourceArchived:
+        for resource_id in resource_ids:
+            increment_downloads(resource_id)
         return {'zip_id': zip_id}
 
     os.remove(file_path)
@@ -937,3 +940,9 @@ def group_show(context, data_dict):
     data['description'] = h.translate_field(data, 'description')
 
     return data
+
+
+def increment_downloads_for_resource(context, data_dict):
+    resource_id = data_dict.get('resource_id')
+    increment_downloads(resource_id)
+    return 'success'

--- a/ckanext/datagovmk/controller.py
+++ b/ckanext/datagovmk/controller.py
@@ -15,7 +15,6 @@ from io import StringIO
 
 from ckan.controllers.package import PackageController
 from ckan.controllers.user import UserController
-from ckanext.datagovmk.model.stats import increment_downloads
 from ckanext.datagovmk.helpers import get_storage_path_for
 from ckanext.datagovmk.utils import (export_resource_to_rdf,
                                      export_resource_to_xml,
@@ -86,8 +85,6 @@ class DownloadController(PackageController):
         :param resource_id: resource id
         :type resource_id: string
         """
-        increment_downloads(resource_id)
-
         context = {'model': model, 'session': model.Session,
                    'user': c.user, 'auth_user_obj': c.userobj}
 
@@ -116,7 +113,7 @@ class DownloadController(PackageController):
         elif 'url' not in rsc:
             abort(404, toolkit._('No download is available'))
         h.redirect_to(rsc['url'])
-    
+
     def download_zip(self, zip_id):
         if not zip_id:
             abort(404, toolkit._('Resource data not found'))
@@ -125,7 +122,7 @@ class DownloadController(PackageController):
 
         if not os.path.isfile(file_path):
             abort(404, toolkit._('Resource data not found'))
-            
+
         if not package_name:
             package_name = 'resources'
         package_name += '.zip'
@@ -512,8 +509,8 @@ class ReportIssueController(BaseController):
         if request.method != 'POST':
             return render('datagovmk/report_issue_form.html', extra_vars=extra_vars)
 
-        
-            
+
+
         context = {'model': model, 'session': model.Session,
                    'user': c.user, 'auth_user_obj': c.userobj}
 
@@ -538,9 +535,9 @@ class ReportIssueController(BaseController):
         })
 
         subject = u'CKAN: Проблем | Problem | Issue: {title}'.format(title=issue_title)
-        
+
         result = send_email(to_user['name'], to_user['email'], subject, email_content)
-        
+
         if not result['success']:
             h.flash_error(result['message'])
         else:
@@ -555,17 +552,17 @@ def get_admin_email():
     If a system configuration is present, it is preffered to the CKAN sysadmins.
     The configuration property is ``ckanext.datagovmk.site_admin_email``.
 
-    If no email is configured explicitly, then the email of the first CKAN 
+    If no email is configured explicitly, then the email of the first CKAN
     sysadmin is used.
 
     :returns: ``str`` the email of the sysadmin to which to send emails with
         issues.
-        
+
     """
     sysadmin_email = config.get('ckanext.datagovmk.site_admin_email', False)
     if sysadmin_email:
         name = sysadmin_email.split('@')[0]
-        return { 
+        return {
             'email': sysadmin_email,
             'name': name
         }

--- a/ckanext/datagovmk/fanstatic/js/modules/increment-downloads.js
+++ b/ckanext/datagovmk/fanstatic/js/modules/increment-downloads.js
@@ -1,0 +1,13 @@
+ckan.module('datagovmk-increment-downloads', function($) {
+    console.log('test')
+    return {
+        initialize: function() {
+            this.el.on('click', function(e) {
+                var data = {
+                    'resource_id': this.options.resource_id
+                }
+                $.get(window.location.origin + '/api/action/datagovmk_increment_downloads_for_resource', data)
+            }.bind(this))
+        }
+    }
+})

--- a/ckanext/datagovmk/fanstatic/js/setup_increment_downloads.js
+++ b/ckanext/datagovmk/fanstatic/js/setup_increment_downloads.js
@@ -1,0 +1,18 @@
+$(document).ready(function() {
+    // Attach JS module for incrementing downloads for a resource
+    //  "Download" and "Download as" buttons
+    var downloadButton = $('a.btn-primary.resource-url-analytics')
+    var resourceId = $('div[data-resource-id]').attr('data-resource-id')
+
+    if (downloadButton.length == 1) {
+        downloadButton.attr('data-module', 'datagovmk-increment-downloads')
+        downloadButton.attr('data-module-resource_id', resourceId)
+    }
+
+    var otherDownloadFormatsContainer = downloadButton.parent().find('ul.dropdown-menu')
+
+    $.each(otherDownloadFormatsContainer.find('a'), function() {
+        $(this).attr('data-module', 'datagovmk-increment-downloads')
+        $(this).attr('data-module-resource_id', resourceId)
+    })
+})

--- a/ckanext/datagovmk/plugin.py
+++ b/ckanext/datagovmk/plugin.py
@@ -130,6 +130,7 @@ class DatagovmkPlugin(plugins.SingletonPlugin, DefaultTranslation):
         return {
             'datagovmk_get_related_datasets': actions.get_related_datasets,
             'datagovmk_prepare_zip_resources': actions.prepare_zip_resources,
+            'datagovmk_increment_downloads_for_resource': actions.increment_downloads_for_resource,
             'package_create': actions.add_spatial_data(package_create),
             'package_update': actions.add_spatial_data(package_update),
             'resource_create': actions.resource_create,

--- a/ckanext/datagovmk/templates/package/resource_read.html
+++ b/ckanext/datagovmk/templates/package/resource_read.html
@@ -1,7 +1,10 @@
+{% resource 'datagovmk/js/setup_increment_downloads.js' %}
+{% resource 'datagovmk/js/modules/increment-downloads.js' %}
+
 {% ckan_extends %}
 
 {% block resource_additional_information_inner %}
-  <div class="module-content">
+  <div class="module-content" data-resource-id="{{ res.id }}">
       {%- block resource_metadata_download -%}
       <div class="btn-group pull-right download-metadata-control">
           <a href="{{ h.url_for(controller='ckanext.datagovmk.controller:BulkDownloadController', action='download_resources_metadata', format='json', package_id=c.pkg_dict['id'], resources=res.id) }}"

--- a/ckanext/datagovmk/templates/package/snippets/resource_download_button.html
+++ b/ckanext/datagovmk/templates/package/snippets/resource_download_button.html
@@ -1,5 +1,7 @@
+{% resource 'datagovmk/js/modules/increment-downloads.js' %}
+
 <div class="btn-group resource-download">
-  <a class="btn btn-success resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
+  <a class="btn btn-success resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}" {% if res.url_type == 'upload' %} data-module="datagovmk-increment-downloads" data-module-resource_id="{{ res.id }}" {% endif %}>
     {% if res.resource_type in ('listing', 'service') %}
       <i class="fa fa-eye"></i> {{ _('View') }}
     {% elif res.resource_type == 'api' %}
@@ -17,16 +19,16 @@
         </button>
         <ul class="dropdown-menu">
           <li>
-            <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, bom=True) }}" target="_blank">
+            <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, bom=True) }}" target="_blank" data-module="datagovmk-increment-downloads" data-module-resource_id="{{ res.id }}">
               <span>CSV</span>
             </a>
-            <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='tsv', bom=True) }}" target="_blank">
+            <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='tsv', bom=True) }}" target="_blank" data-module="datagovmk-increment-downloads" data-module-resource_id="{{ res.id }}">
               <span>TSV</span>
             </a>
-            <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='json') }}" target="_blank">
+            <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='json') }}" target="_blank" data-module="datagovmk-increment-downloads" data-module-resource_id="{{ res.id }}">
               <span>JSON</span>
             </a>
-            <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='xml') }}" target="_blank">
+            <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='xml') }}" target="_blank" data-module="datagovmk-increment-downloads" data-module-resource_id="{{ res.id }}">
               <span>XML</span>
             </a>
           </li>


### PR DESCRIPTION
Resource downloads are now counted only when the "Download" and "Download as" (dropdown list with CSV, TSV...) buttons are clicked. This includes the Download buttons located in a dataset page where all resources are displayed, as well as a single resource page.

Also, when downloading multiple resources in a zip archive, all selected resources in the zip are counted as well.