### PR TITLE
Added cascade on delete for user_authority_dataset.

### DIFF
--- a/ckanext/datagovmk/model/user_authority_dataset.py
+++ b/ckanext/datagovmk/model/user_authority_dataset.py
@@ -51,9 +51,9 @@ def define_user_authority_dataset_table():
         metadata,
         Column('id', types.UnicodeText, primary_key=True, default=make_uuid),
         Column('authority_id', types.UnicodeText,
-               ForeignKey('user_authority.id')),
+               ForeignKey('user_authority.id', ondelete='CASCADE')),
         Column('dataset_id', types.UnicodeText,
-               ForeignKey('package.id')),
+               ForeignKey('package.id', ondelete='CASCADE')),
         Column('created', types.DateTime, default=datetime.datetime.now),
     )
 


### PR DESCRIPTION
There was an integrity error when purging datasets, if they have user authority. I've modified the model to have  ```ON DELETE CASCADE```, so these entries would be removed automatically.

Additionally, we'll have to modify the database manually on staging/prod.