### PR TITLE
Fix perf issues on homepage

### DIFF
--- a/ckanext/datagovmk/commands.py
+++ b/ckanext/datagovmk/commands.py
@@ -17,6 +17,11 @@ from ckanext.datagovmk.model.user_authority \
     import setup as setup_user_authority_table
 from ckanext.datagovmk.model.user_authority_dataset \
     import setup as setup_user_authority_dataset_table
+from ckanext.datagovmk.model.most_active_organizations \
+    import setup as setup_most_active_organizations_table
+from ckanext.datagovmk.model.most_active_organizations import MostActiveOrganizations
+from ckanext.datagovmk.helpers import get_most_active_organizations
+from ckan.model.meta import Session
 
 log = getLogger('ckanext.datagovmk')
 
@@ -58,7 +63,7 @@ class CheckOutdatedDatasets(CkanCommand):
     def command(self):
         self._load_config()
         self._processl_all_datasets(self._check_dataset_if_outdated)
-    
+
     def _processl_all_datasets(self, process_dataset):
         context = {'ignore_auth': True}
         page = 0
@@ -86,12 +91,12 @@ class CheckOutdatedDatasets(CkanCommand):
         frequency = dataset.get('frequency')
         if not frequency:
             return  # ignore, not scheduled for periodic updates
-        
+
         frequency = frequency.split('/')[-1]
 
         if frequency in IGNORE_PERIODICITY:
             return  # not scheduled by choice
-        
+
         periodicity = PERIODICITY.get(frequency.upper())
         if not periodicity:
             log.warning('Dataset %s has periodicity %s which we do not handle', dataset['id'], frequency)
@@ -101,7 +106,7 @@ class CheckOutdatedDatasets(CkanCommand):
         last_modified = self._get_last_modified(dataset)
         if not last_modified:
             return  # ignore this one
-        
+
         now = datetime.now()
 
         diff = now - last_modified
@@ -109,7 +114,7 @@ class CheckOutdatedDatasets(CkanCommand):
             log.debug('Dataset %s needs to be updated.', dataset['id'])
             self.notify_dataset_outdated(dataset, last_modified)
             log.info('Notifications for dataset update has beed sent. Dataset: %s', dataset['id'])
-    
+
 
     def _get_last_modified(self, dataset):
         resources = dataset.get('resources')
@@ -130,7 +135,7 @@ class CheckOutdatedDatasets(CkanCommand):
             maintainer['username'] = dataset.get('maintainer') or dataset['maintainer_email'].split('@')[0]
 
             users.append(maintainer)
-        
+
         if dataset.get('creator_user_id'):
             try:
                 creator = toolkit.get_action('user_show')({'ignore_auth' :True}, {'id': dataset['creator_user_id']})
@@ -162,7 +167,7 @@ class CheckOutdatedDatasets(CkanCommand):
                 self._send_notification(dataset_url, dataset_update_url, dataset_title, user)
             except Exception as e:
                 log.error('Failed to send email notification for dataset %s: %s', dataset['id'], e)
-    
+
     def _send_notification(self, dataset_url, dataset_update_url, dataset_title, user):
         subject = u'CKAN: Потсетување за ажурирање на податочниот сет „{title}“ | '\
                   u'Kujtesë për përditësimin e të dhënave "{title}" | '\
@@ -202,7 +207,7 @@ def _load_resource_from_path(url):
 
 
 class InitDB(CkanCommand):
-    ''' Initialize UserAuthority tables. '''
+    ''' Initialize datagovmk DB tables. '''
 
     summary = __doc__.split('\n')[0]
     usage = __doc__
@@ -211,8 +216,89 @@ class InitDB(CkanCommand):
 
     def command(self):
         self._load_config()
-        
+
         setup_user_authority_table()
         setup_user_authority_dataset_table()
+        setup_most_active_organizations_table()
 
-        log.info('User authorities tables initialized')
+        log.info('datagovmk DB tables initialized')
+
+
+class FetchMostActiveOrganizations(CkanCommand):
+    ''' Fetches most active organizations. '''
+
+    summary = __doc__.split('\n')[0]
+    usage = __doc__
+    max_args = 0
+    min_args = 0
+
+    def command(self):
+        self._load_config()
+        self._fetch_data()
+
+    def _fetch_data(self):
+        orgs = toolkit.get_action('organization_list')({}, {})
+        last_updated_orgs = []
+
+        for org_name in orgs:
+            org = toolkit.get_action('organization_show')({'user': None}, {
+                'id': org_name,
+                'include_datasets': True,
+                'include_dataset_count': False,
+                'include_extras': True,
+                'include_users': False,
+                'include_groups': False,
+                'include_tags': False,
+                'include_followers': False,
+            })
+
+            last_updated_datasets = []
+
+            for dataset in org.get('packages'):
+                dataset_full = toolkit.get_action('package_show')({}, {
+                    'id': dataset.get('id'),
+                })
+                last_modified_resource = ''
+
+                for resource in dataset_full.get('resources'):
+                    field = 'last_modified'
+                    if resource.get('last_modified') is None:
+                        field = 'created'
+
+                    if resource.get(field) > last_modified_resource:
+                        last_modified_resource = resource.get(field)
+
+                last_updated_datasets.append(last_modified_resource)
+            last_updated_datasets = sorted(last_updated_datasets, reverse=True)
+
+            if last_updated_datasets:
+                last_modified_dataset = last_updated_datasets[0]
+                last_updated_orgs.append({
+                    'org': org, 'last_modified': last_modified_dataset
+                })
+
+        sorted_orgs = sorted(
+            last_updated_orgs,
+            key=lambda k: k['last_modified'],
+            reverse=True
+        )
+
+        orgs = map(lambda x: x.get('org'), sorted_orgs)
+
+        Session.query(MostActiveOrganizations).delete()
+
+        s = Session()
+        objects = []
+
+        for org in orgs:
+            data = {
+                'org_id': org.get('id'),
+                'org_name': org.get('name'),
+                'org_display_name': org.get('display_name'),
+            }
+            objects.append(MostActiveOrganizations(**data))
+
+        s.bulk_save_objects(objects)
+        s.commit()
+
+        log.info('Successfully cached most active organizations.')

--- a/ckanext/datagovmk/model/most_active_organizations.py
+++ b/ckanext/datagovmk/model/most_active_organizations.py
@@ -1,0 +1,43 @@
+import datetime
+
+import ckan.logic as logic
+from ckan import model
+from ckan.model.meta import metadata, mapper, Session
+from ckan.model.types import make_uuid
+from ckan.model.domain_object import DomainObject
+
+from sqlalchemy import types, ForeignKey, Column, Table, desc
+
+__all__ = [
+    'MostActiveOrganizations',
+    'most_active_organizations_table',
+    'setup'
+]
+
+most_active_organizations_table = None
+
+
+class MostActiveOrganizations(DomainObject):
+
+    @classmethod
+    def get_all(cls, limit=5):
+        obj = Session.query(cls).autoflush(False)
+        return obj.limit(limit).all()
+
+most_active_organizations_table = Table(
+    'most_active_organizations',
+    metadata,
+    Column('id', types.UnicodeText, primary_key=True, default=make_uuid),
+    Column('org_id', types.UnicodeText),
+    Column('org_name', types.UnicodeText),
+    Column('org_display_name', types.UnicodeText),
+)
+
+mapper(
+    MostActiveOrganizations,
+    most_active_organizations_table,
+)
+
+
+def setup():
+    metadata.create_all(model.meta.engine)

--- a/ckanext/datagovmk/templates/home/layout1.html
+++ b/ckanext/datagovmk/templates/home/layout1.html
@@ -33,7 +33,7 @@
               {% if popular_organizations %}
               <ul class="list-unstyled">
                 {% for organization in popular_organizations %}
-                  <li><i class="fa fa-university"></i> <a href="{{ h.url_for(controller='organization', action='read', id=organization.name) }}">{{ organization.display_name }}</a></li>
+                  <li><i class="fa fa-university"></i> <a href="{{ h.url_for(controller='organization', action='read', id=organization.org_name) }}">{{ organization.org_display_name }}</a></li>
                 {% endfor %}
               </ul>
               {% else %}

--- a/ckanext/datagovmk/tests/test_helpers.py
+++ b/ckanext/datagovmk/tests/test_helpers.py
@@ -13,9 +13,12 @@ from ckanext.datagovmk.model.user_authority \
     import setup as setup_user_authority_table
 from ckanext.datagovmk.model.user_authority_dataset \
     import setup as setup_user_authority_dataset_table
+from ckanext.datagovmk.model.most_active_organizations \
+    import setup as setup_most_active_organizations_table
 from ckanext.datagovmk.model.user_authority import UserAuthority
 from ckanext.c3charts.model.featured_charts import setup as setup_featured_charts_table
 from ckanext.googleanalytics.dbutil import update_package_visits
+from ckanext.datagovmk.commands import fetch_most_active_orgs
 
 
 class HelpersBase(object):
@@ -25,6 +28,7 @@ class HelpersBase(object):
         setup_user_authority_table()
         setup_user_authority_dataset_table()
         setup_featured_charts_table()
+        setup_most_active_organizations_table()
 
         rebuild()
 
@@ -95,17 +99,24 @@ class TestHelpers(HelpersBase, test_helpers.FunctionalTestBase):
         dataset4 = factories.Dataset(owner_org=organization3['id'])
         resource7 = factories.Resource(package_id=dataset4['id'], url='http://google.com', skip_update_package_stats=True)
 
+        fetch_most_active_orgs()
         result = helpers.get_most_active_organizations()
+
         assert len(result) == 3
-        assert result[0]['id'] == organization3['id']
+        assert result[0].org_id == organization3['id']
+
         resource8 = factories.Resource(package_id=dataset['id'], url='http://google.com', skip_update_package_stats=True)
+
+        fetch_most_active_orgs()
         result = helpers.get_most_active_organizations()
-        assert result[0]['id'] == organization['id']
+
+        assert result[0].org_id == organization['id']
 
         for i in range(10):
             organizationMultiple = factories.Organization()
             create_dataset(owner_org=organizationMultiple['id'])
 
+        fetch_most_active_orgs()
         result = helpers.get_most_active_organizations(limit=7)
 
         assert len(result) == 7

--- a/scripts/cron_jobs/most_active_orgs.sh
+++ b/scripts/cron_jobs/most_active_orgs.sh
@@ -1,0 +1,4 @@
+CONFIG_FILE_LOCATION=$1
+
+# Every hour
+paster --plugin=ckanext-datagovmk fetch_most_active_orgs -c $CONFIG_FILE_LOCATION

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
         [paste.paster_command]
         check_outdated_datasets=ckanext.datagovmk.commands:CheckOutdatedDatasets
         initdb=ckanext.datagovmk.commands:InitDB
+        fetch_most_active_orgs=ckanext.datagovmk.commands:FetchMostActiveOrganizations
     ''',
 
     # If you are changing from the default layout of your extension, you may


### PR DESCRIPTION
On the homepage, a helper is called to display the most active organizations. The helper makes many calls to Solr and Postgres so it is not very fast. This PR fixes the issues on the homepage by caching the most active organizations. So instead of calling the helper every time the page loads, it fetches already cached data.

A `paster` script was created to load the data in the DB. It can be invoked by running the command `paster --plugin=ckanext-datagovmk fetch_most_active_orgs -c /path/to/file.ini`. This script should be run periodically.

The DB table where most active organizations are stored, is initialized by calling the `paster` command `paster --plugin=ckanext-datagovmk initdb -c /path/to/file.ini`.