### PR TITLE
Fix/most active org name

### DIFF
--- a/ckanext/datagovmk/commands.py
+++ b/ckanext/datagovmk/commands.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
 
+import os
+import io
+import inspect
+import json
+
 from logging import getLogger
 from datetime import timedelta, datetime
 from dateutil import parser
@@ -10,9 +15,7 @@ import ckan.lib.helpers as h
 import ckan.lib.mailer as ckan_mailer
 from ckan.lib import base
 from ckan.common import config
-import os
-import io
-import inspect
+
 from ckanext.datagovmk.model.user_authority \
     import setup as setup_user_authority_table
 from ckanext.datagovmk.model.user_authority_dataset \
@@ -290,8 +293,6 @@ def fetch_most_active_orgs():
 
     s = Session()
     objects = []
-
-    import json
 
     for org in orgs:
         data = {

--- a/ckanext/datagovmk/commands.py
+++ b/ckanext/datagovmk/commands.py
@@ -291,11 +291,13 @@ def fetch_most_active_orgs():
     s = Session()
     objects = []
 
+    import json
+
     for org in orgs:
         data = {
             'org_id': org.get('id'),
             'org_name': org.get('name'),
-            'org_display_name': org.get('display_name'),
+            'org_display_name': json.dumps(org.get('title_translated', None)),
         }
         objects.append(MostActiveOrganizations(**data))
 

--- a/ckanext/datagovmk/helpers.py
+++ b/ckanext/datagovmk/helpers.py
@@ -1,9 +1,10 @@
 """datagovmk custom helpers.
 """
 import os
+import json
 
 from ckan.plugins import toolkit
-from ckan.lib import search
+from ckan.lib import search, i18n
 from datetime import datetime
 from ckan.common import config
 from ckanext.datagovmk.model.stats import (get_stats_for_package,
@@ -295,3 +296,19 @@ def get_catalog_count():
         'fq': 'extras_org_catalog_enabled:true'
     }
     return toolkit.get_action('package_search')(data_dict=data_dict)['count']
+
+
+def get_translated(json_str):
+    """ Converts json to dict and get the appropriate value for the current language
+
+    :param json_str: the json with translates, example {'mk': '', 'en': '', 'sq': ''}
+    :type json_str: str/unicode
+    :returns: the appropriate value for the current language from the json
+    :rtype: str
+    """
+    try:
+        lang = i18n.get_lang()
+        d = json.loads(json_str)
+        return d.get(lang, None) if isinstance(d, dict) else ''
+    except:
+        return ''

--- a/ckanext/datagovmk/helpers.py
+++ b/ckanext/datagovmk/helpers.py
@@ -299,7 +299,7 @@ def get_catalog_count():
 
 
 def get_translated(json_str):
-    """ Converts json to dict and get the appropriate value for the current language
+    """ Converts json to dict and gets the appropriate value for the current language
 
     :param json_str: the json with translates, example {'mk': '', 'en': '', 'sq': ''}
     :type json_str: str/unicode

--- a/ckanext/datagovmk/plugin.py
+++ b/ckanext/datagovmk/plugin.py
@@ -117,7 +117,9 @@ class DatagovmkPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'datagovmk_get_catalog_count':
                 helpers.get_catalog_count,
             'datagovmk_get_org_title_desc':
-                helpers.get_org_title_desc
+                helpers.get_org_title_desc,
+            'datagovmk_get_translated':
+                helpers.get_translated
         }
 
     # IActions

--- a/ckanext/datagovmk/templates/home/layout1.html
+++ b/ckanext/datagovmk/templates/home/layout1.html
@@ -33,7 +33,7 @@
               {% if popular_organizations %}
               <ul class="list-unstyled">
                 {% for organization in popular_organizations %}
-                  <li><i class="fa fa-university"></i> <a href="{{ h.url_for(controller='organization', action='read', id=organization.org_name) }}">{{ organization.org_display_name }}</a></li>
+                  <li><i class="fa fa-university"></i> <a href="{{ h.url_for(controller='organization', action='read', id=organization.org_name) }}">{{ h.datagovmk_get_translated(organization.org_display_name) }}</a></li>
                 {% endfor %}
               </ul>
               {% else %}

--- a/ckanext/datagovmk/tests/test_helpers.py
+++ b/ckanext/datagovmk/tests/test_helpers.py
@@ -1,5 +1,7 @@
 # coding: utf8
 
+import json
+
 from ckan import plugins
 from ckan.tests import helpers as test_helpers
 from ckanext.datagovmk import helpers
@@ -339,11 +341,13 @@ class TestHelpers(HelpersBase, test_helpers.FunctionalTestBase):
         assert desc == u'description on english'
 
     def test_get_translated(self):
-        json_str = '''{
+        title_translated = {
             'en': 'title on english',
             'mk': u'наслов на македонски',
             'sq': 'titulli i shqiptar'
-        }'''
+        }
+
+        json_str = json.loads(title_translated)
 
         set_lang('mk')
         t = helpers.get_translated(json_str)

--- a/ckanext/datagovmk/tests/test_helpers.py
+++ b/ckanext/datagovmk/tests/test_helpers.py
@@ -338,6 +338,25 @@ class TestHelpers(HelpersBase, test_helpers.FunctionalTestBase):
         assert title == u'title on english'
         assert desc == u'description on english'
 
+    def test_get_translated(self):
+        json_str = '''{
+            'en': 'title on english',
+            'mk': u'наслов на македонски',
+            'sq': 'titulli i shqiptar'
+        }'''
+
+        set_lang('mk')
+        t = helpers.get_translated(json_str)
+        assert t == u'наслов на македонски'
+
+        set_lang('en')
+        t = helpers.get_translated(json_str)
+        assert t == 'title on english'
+
+        set_lang('sq')
+        t = helpers.get_translated(json_str)
+        assert t == 'titulli i shqiptar'
+
     @test_helpers.change_config('ckan.auth.create_unowned_dataset', True)
     def test_get_org_catalog(self):
         org = factories.Organization()

--- a/ckanext/datagovmk/tests/test_helpers.py
+++ b/ckanext/datagovmk/tests/test_helpers.py
@@ -347,7 +347,7 @@ class TestHelpers(HelpersBase, test_helpers.FunctionalTestBase):
             'sq': 'titulli i shqiptar'
         }
 
-        json_str = json.loads(title_translated)
+        json_str = json.dumps(title_translated)
 
         set_lang('mk')
         t = helpers.get_translated(json_str)


### PR DESCRIPTION
Stores title_translated as display_name in most active organizations as json str. When display name is needed datagovmk_get_translated helper should be used to retrieve the corresponding value for the current language.

`paster --plugin=ckanext-datagovmk fetch_most_active_orgs -c /path/to/filename.ini` should be execute right after this PR is deployed.