### PR TITLE
Reorder About element in main navigation

### DIFF
--- a/ckanext/datagovmk/templates/snippets/main_navigation.html
+++ b/ckanext/datagovmk/templates/snippets/main_navigation.html
@@ -2,10 +2,10 @@
   ('search', _('Datasets')),
   ('organizations_index', _('Organizations')),
   ('group_index', _('Groups')),
-  ('home.about', _('About')),
   ('organogram_index', _('Organogram')),
   ('ckanext_showcase_index', _('Showcases')),
   ('ckanext_experience_index', _('Experiences')),
   ('reports', _('Reports')),
   ('datarequests_index', _('Data Requests') + h.get_open_datarequests_badge()),
+  ('home.about', _('About')),
 ) }}


### PR DESCRIPTION
This PR moves the About element in the main navigation to the last position, after all other navigation items.