### PR TITLE
Fix issue with forbidden when a user registers

### DIFF
--- a/ckanext/datagovmk/lib.py
+++ b/ckanext/datagovmk/lib.py
@@ -18,7 +18,7 @@ def get_activation_link(user):
     :type user: dict
     :returns: activation link
     :rtype: str
-    """ 
+    """
     controller_path = 'ckanext.datagovmk.controller:DatagovmkUserController'
     return h.url_for(controller=controller_path,
                      action='perform_activation',
@@ -32,7 +32,7 @@ def request_activation(user):
     :param user: the user for whom an activation link should be requested
     :type user: dict
     """
-    
+
     create_activation_key(user)
     site_title = config.get('ckan.site_title')
     site_url = config.get('ckan.site_url')
@@ -48,7 +48,7 @@ def request_activation(user):
     })
     subject = subject.split('\n')[0]
 
-    mailer.mail_user(user, subject, body)
+    mailer.mail_recipient(user.name, user.email, subject, body, headers={})
 
 
 def verify_activation_link(user, key):


### PR DESCRIPTION
This PR fixes an issue when a user registers on the portal, i.e. if the user enters cyrillic characters in the field "Full Name", the servers returns a 403 Forbidden error. This was caused when the activation email should be sent by the mail system Amazon SES which does not support UTF-8 characters to be present in the "To" field in the email, and there is no way to configure Amazon SES to use UTF-8.

So now, in the "To" field in the email, instead of the full name like "John Smith <john.smith@test.com>" it will be used the username "johnsmith <john.smith@test.com>".